### PR TITLE
Add debug mode, fix freezes on some ROMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ Default combination on startup is QWERTY. Press TAB to change between QWERTY and
 Right now the emulator can boot some ROMs successfully, like Pong (1 player) and Tetris. Some programs like Tic-tac-toe cause freezes.
 
 ## TODO:
-* Fix freezes on some ROMs;
-* Clear and organize code;
+* ~~Fix freezes on some ROMs;~~ *Done. This was due to a wrong implementation of the 0xFX0A opcode.*
+* Clear and organize code; (*Partially done*)
 * Implement sound effect (beep);
 * ~~Optimize code to run better on higher resolutions.~~ *Done. While maximized some games reach 290 FPS.*
-* Make an FPS cap to slow down the programs.
+* ~~Make an FPS cap to slow down the programs.~~ *Program runs at 60 FPS with updated graphics driver.*
 
 
 ## Used references
@@ -58,6 +58,6 @@ Right now the emulator can boot some ROMs successfully, like Pong (1 player) and
 * http://devernay.free.fr/hacks/chip8/C8TECH10.HTM
 
 ## Acknowledgements
-* [Tiago Toledo Junior](https://github.com/TNanukem) for giving the idea of this project;
+* [Tiago Toledo Junior](https://github.com/TNanukem), a good friend, he gave the original idea of this project;
 * [David Jowett](https://github.com/DavidJowett): The OpenGL implementation is based on his CHIP-8 emulator 
 (https://github.com/DavidJowett/chip8-emulator).

--- a/chip8.h
+++ b/chip8.h
@@ -16,7 +16,7 @@ typedef struct chip8 {
 	unsigned short pc;		/* Program Counter */
 	unsigned char gfx[WIDTH*HEIGHT];	/* Graphics matrix - Black and white screen of 2048 pixels (64x32) */
 	unsigned char update_screen;	/* If this is true (1), update the screen */
-
+	
 	/* Interupts and hardware registers */
 	unsigned char delay_timer;
 	unsigned char sound_timer;
@@ -28,6 +28,9 @@ typedef struct chip8 {
 	/* Hexadecimal keypad */
 	unsigned char keypad[16];
 	unsigned char key_layout; /* 0: QWERTY; 1: AZERTY */
+
+	/* Debug flag */
+	unsigned char debug;
 } Chip8;
 
 extern unsigned char chip8_fontset[80];


### PR DESCRIPTION
### Debug mode:
- Prints to stdout every assembly instruction done by the current program in execution;
- Can be turned on or off by a flag.

### Freezes on some ROMs
They were caused by an incorrect implementation of the 0xFX0A (LD) instruction, which halts the entire program to await for an input in stdin (that obviously isn't going to work).

